### PR TITLE
Fix click-through

### DIFF
--- a/src/keymon/shaped_window.py
+++ b/src/keymon/shaped_window.py
@@ -80,6 +80,12 @@ class ShapedWindow(gtk.Window):
       # This method only is called when mouse is pressed, so there will be a
       # release and fade_away call, no need to set up another timer.
     super(ShapedWindow, self).show()
+    # Fix click-through
+    pm = gtk.gdk.Pixmap(None, self.get_size()[0], self.get_size()[1], 1)
+    pmcr = pm.cairo_create()
+    pmcr.rectangle(0, 0, 1, 1)
+    pmcr.fill()
+    self.input_shape_combine_mask(pm, 0, 0)
 
   def maybe_show(self):
     if self.shown or not self.timeout_timer:


### PR DESCRIPTION
When follow_mouse is turned on, I am unable to click. While this should be possible using `win.shape_combine_mask`, it didn't work for me. 

I added a separate call to `input_shape_combine_mask` and recalculate the mask on cursor move to make it work again. I'm not sure whether this is the "correct" way of doing it, though.